### PR TITLE
Fix code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/static/vendor/bootstrap/js/bootstrap.js
+++ b/static/vendor/bootstrap/js/bootstrap.js
@@ -135,6 +135,9 @@
         selector = hrefAttr && hrefAttr !== '#' ? hrefAttr.trim() : '';
       }
 
+      // Sanitize the selector to prevent XSS
+      selector = CSS.escape(selector);
+
       try {
         return document.querySelector(selector) ? selector : null;
       } catch (_) {

--- a/static/vendor/jquery/jquery.js
+++ b/static/vendor/jquery/jquery.js
@@ -10341,7 +10341,9 @@ jQuery.parseHTML = function( data, context, keepScripts ) {
 
 	// Single tag
 	if ( parsed ) {
-		return [ context.createElement( parsed[ 1 ] ) ];
+		// Sanitize the parsed tag name to prevent XSS
+		var tagName = parsed[ 1 ].replace(/[^a-zA-Z0-9-]/g, '');
+		return [ context.createElement( tagName ) ];
 	}
 
 	parsed = buildFragment( [ data ], context, scripts );


### PR DESCRIPTION
Fixes [https://github.com/Soatrix/PXEPro/security/code-scanning/10](https://github.com/Soatrix/PXEPro/security/code-scanning/10)

To fix the problem, we need to ensure that any data extracted from the DOM and used as HTML is properly sanitized or escaped to prevent XSS attacks. In this case, we should avoid using `jQuery.parseHTML` directly with untrusted data. Instead, we can use a safer method to handle the data.

1. Modify the `getSelectorFromElement` function to ensure the selector is properly sanitized.
2. Update the `jQuery.parseHTML` function to handle the data more securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
